### PR TITLE
Weak hacks to work around broken older parser(bz:1158938)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(os.path.join(here, 'README.md')) as f:
 
 
 setup(name='signing_clients',
-    version='0.1.11',
+    version='0.1.13',
     description="Applications signature/manifest manipulator and receipt verifier",
     long_description=README,
     classifiers=[

--- a/signing_clients/apps.py
+++ b/signing_clients/apps.py
@@ -138,6 +138,7 @@ class Section(object):
 
 class Manifest(list):
     version = '1.0'
+    extra_newline = False
 
     def __init__(self, *args, **kwargs):
         super(Manifest, self).__init__(*args)
@@ -222,7 +223,10 @@ class Manifest(list):
         return "\n".join([str(i) for i in self])
 
     def __str__(self):
-        return "\n".join([self.header, "", self.body])
+        segments = [self.header, "", self.body]
+        if self.extra_newline:
+            segments.append("")
+        return "\n".join(segments)
 
 
 class Signature(Manifest):
@@ -237,8 +241,11 @@ class Signature(Manifest):
 
     @property
     def header(self):
-        header = super(Signature, self).header
-        return "\n".join([header, ] + self.digest_manifest)
+        segments = [str(super(Signature, self).header), ]
+        segments.extend(self.digest_manifest)
+        if self.extra_newline:
+            segments.append("")
+        return "\n".join(segments)
 
     # So we can omit the individual signature sections
     def __str__(self):
@@ -255,18 +262,18 @@ class JarExtractor(object):
     """
 
     def __init__(self, path, outpath=None, ids=None,
-                 omit_signature_sections=False):
+                 omit_signature_sections=False, extra_newlines=False):
         """
         """
         self.inpath = path
         self.outpath = outpath
         self._digests = []
         self.omit_sections = omit_signature_sections
-
+        self.extra_newlines = extra_newlines
         self._manifest = None
         self._sig = None
-
         self.ids = ids
+
         def mksection(data, fname):
             digests = _digest(data)
             item = Section(fname, algos=tuple(digests.keys()),
@@ -291,7 +298,8 @@ class JarExtractor(object):
     @property
     def manifest(self):
         if not self._manifest:
-            self._manifest = Manifest(self._digests)
+            self._manifest = Manifest(self._digests,
+                                      extra_newline=self.extra_newlines)
         return self._manifest
 
     @property
@@ -302,7 +310,8 @@ class JarExtractor(object):
         if not self._sig:
             self._sig = Signature([self._sign(f) for f in self._digests],
                                   digest_manifests=_digest(str(self.manifest)),
-                                  omit_individual_sections=self.omit_sections)
+                                  omit_individual_sections=self.omit_sections,
+                                  extra_newline=self.extra_newlines)
         return self._sig
 
     @property

--- a/signing_clients/apps.py
+++ b/signing_clients/apps.py
@@ -138,6 +138,9 @@ class Section(object):
 
 class Manifest(list):
     version = '1.0'
+    # Older versions of Firefox crash if a JAR manifest style file doesn't
+    # end in a blank line("\n\n").  For more details see:
+    # https://bugzilla.mozilla.org/show_bug.cgi?id=1158467
     extra_newline = False
 
     def __init__(self, *args, **kwargs):
@@ -241,7 +244,7 @@ class Signature(Manifest):
 
     @property
     def header(self):
-        segments = [str(super(Signature, self).header), ]
+        segments = [str(super(Signature, self).header)]
         segments.extend(self.digest_manifest)
         if self.extra_newline:
             segments.append("")


### PR DESCRIPTION
Add the option to forcibly add an additional trailing newline to the manifest
and signature files generated for a given XPI. See
https://bugzilla.mozilla.org/show_bug.cgi?id=1158467 for details on the bug
addressed.

r? @andymckay @kumar303 