### PR TITLE
Case insensitive fnmatch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(os.path.join(here, 'README.md')) as f:
 
 
 setup(name='signing_clients',
-    version='0.1.13',
+    version='0.1.14',
     description="Applications signature/manifest manipulator and receipt verifier",
     long_description=README,
     classifiers=[

--- a/signing_clients/apps.py
+++ b/signing_clients/apps.py
@@ -62,7 +62,9 @@ def ignore_certain_metainf_files(filename):
               "META-INF/ids.json")
 
     for glob in ignore:
-        if fnmatch.fnmatch(filename, glob):
+        # Explicitly match against all upper case to prevent the kind of
+        # runtime errors that lead to https://bugzil.la/1169574
+        if fnmatch.fnmatchcase(filename.upper(), glob.upper()):
             return True
     return False
 

--- a/signing_clients/tests/__init__.py
+++ b/signing_clients/tests/__init__.py
@@ -17,7 +17,8 @@ from signing_clients.apps import (
     ParsingError,
     ZipFile,
     file_key,
-    get_signature_serial_number
+    get_signature_serial_number,
+    ignore_certain_metainf_files
 )
 
 
@@ -209,3 +210,10 @@ class SigningTest(unittest.TestCase):
         # And make sure the manifest is correct
         signed = JarExtractor(signed_file, omit_signature_sections=True)
         self.assertEqual(str(extracted.manifest), str(signed.manifest))
+
+    # See https://bugzil.la/1169574
+    def test_12_metainf_case_sensitivity(self):
+        self.assertTrue(ignore_certain_metainf_files('meta-inf/manifest.mf'))
+        self.assertTrue(ignore_certain_metainf_files('MeTa-InF/MaNiFeSt.Mf'))
+        self.assertFalse(ignore_certain_metainf_files('meta-inf/pickles.mf'))
+


### PR DESCRIPTION
Python's fnmatch module uses the OS's case sensitivity rules.  This results in different behaviour on real *NIXes.  Yes, I am biased against OS X.

r? @kumar303