### PR TITLE
Make signing-clients python3 compatible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,26 +1,50 @@
-""" Setup file.
-"""
+import sys
 import os
+import codecs
 from setuptools import setup, find_packages
 
-here = os.path.abspath(os.path.dirname(__file__))
 
-with open(os.path.join(here, 'README.md')) as f:
-    README = f.read()
+# Helper to publish to pypi. Just call `python setup.py publish`
+if sys.argv[-1] == 'publish':
+    os.system('python setup.py sdist upload')
+    os.system('python setup.py bdist_wheel upload')
+    print('You probably want to also tag the version now:')
+    print('  git tag -a %s -m "version %s"' % (version, version))
+    print('  git push --tags')
+    sys.exit()
 
 
-setup(name='signing_clients',
-    version='0.1.14',
-    description="Applications signature/manifest manipulator and receipt verifier",
-    long_description=README,
+def read(*parts):
+    filename = os.path.join(os.path.dirname(__file__), *parts)
+    with codecs.open(filename, encoding='utf-8') as fp:
+        return fp.read()
+
+
+setup(
+    name='signing_clients',
+    version='0.2.0',
+    description='Applications signature/manifest manipulator and receipt verifier',
+    long_description=read('README.md'),
     classifiers=[
-        "Programming Language :: Python",
+        'Development Status :: 5 - Production/Stable',
+        'Topic :: Security :: Cryptography',
+        'Topic :: Software Development :: Libraries :: Python Modules',
+        'Programming Language :: Python',
+        'Operating System :: OS Independent',
+        'Intended Audience :: Developers',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: Implementation :: CPython',
     ],
-    keywords="web services",
+    keywords='web services',
     author='Ryan Tilder',
-    author_email="service-dev@mozilla.com",
-    url="http://mozilla.org",
-    install_requires=["M2Crypto"],
+    author_email='service-dev@mozilla.com',
+    url='http://mozilla.org',
+    install_requires=['asn1crypto'],
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     author='Ryan Tilder',
     author_email='service-dev@mozilla.com',
     url='http://mozilla.org',
-    install_requires=['asn1crypto'],
+    install_requires=['asn1crypto', 'six'],
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,

--- a/signing_clients/tests/__init__.py
+++ b/signing_clients/tests/__init__.py
@@ -106,7 +106,7 @@ SHA1-Digest: B5HkCxgt6fXNr+dWPwXH2aALVWk=
 """
 
 
-def test_file(fname):
+def get_file(fname):
     return os.path.join(os.path.dirname(__file__), fname)
 
 
@@ -120,7 +120,7 @@ class SigningTest(unittest.TestCase):
         return os.path.join(self.tmpdir, fname)
 
     def _extract(self, omit=False, newlines=False):
-        return JarExtractor(test_file('test-jar.zip'),
+        return JarExtractor(get_file('test-jar.zip'),
                             omit_signature_sections=omit,
                             extra_newlines=newlines)
 
@@ -157,17 +157,17 @@ class SigningTest(unittest.TestCase):
         self.assertRaises(ParsingError, Manifest.parse, BROKEN_MANIFEST)
 
     def test_07_wrapping(self):
-        extracted = JarExtractor(test_file('test-jar-long-path.zip'),
+        extracted = JarExtractor(get_file('test-jar-long-path.zip'),
                                  omit_signature_sections=False)
         self.assertEqual(str(extracted.manifest), VERY_LONG_MANIFEST)
 
     def test_08_unicode(self):
-        extracted = JarExtractor(test_file('test-jar-unicode.zip'),
+        extracted = JarExtractor(get_file('test-jar-unicode.zip'),
                                  omit_signature_sections=False)
         self.assertEqual(str(extracted.manifest), UNICODE_MANIFEST)
 
     def test_09_serial_number_extraction(self):
-        with open(test_file('zigbert.test.pkcs7.der'), 'r') as f:
+        with open(get_file('zigbert.test.pkcs7.der'), 'r') as f:
             serialno = get_signature_serial_number(f.read())
         # Signature occured on Thursday, January 22nd 2015 at 11:02:22am PST
         # The signing service returns a Python time.time() value multiplied
@@ -178,7 +178,7 @@ class SigningTest(unittest.TestCase):
         # This zip contains META-INF/manifest.mf, META-INF/zigbert.sf, and
         # META-INF/zigbert.rsa in addition to the contents of the basic test
         # archive test-jar.zip
-        extracted = JarExtractor(test_file('test-jar-meta-inf-exclude.zip'),
+        extracted = JarExtractor(get_file('test-jar-meta-inf-exclude.zip'),
                                  omit_signature_sections=True)
         self.assertEqual(str(extracted.manifest), MANIFEST)
 
@@ -186,10 +186,10 @@ class SigningTest(unittest.TestCase):
     #       Much more readily done in trunion source when signing-clients is
     #       merged there.
     def test_11_make_signed(self):
-        extracted = JarExtractor(test_file('test-jar.zip'),
+        extracted = JarExtractor(get_file('test-jar.zip'),
                                  omit_signature_sections=True)
         # Not a valid signature but a PKCS7 data blob, at least
-        with open(test_file('zigbert.test.pkcs7.der'), 'r') as f:
+        with open(get_file('zigbert.test.pkcs7.der'), 'r') as f:
             signature = f.read()
             signature_digest = sha.new(signature)
         signed_file = self.tmp_file('test-jar-signed.zip')

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+[tox]
+envlist = py27,py35,py36
+
+[testenv]
+setenv =
+    PYTHONPATH={toxinidir}
+    PYTHONDONTWRITEBYTECODE=1
+commands =
+    pip install --upgrade pip setuptools wheel
+    pip install --use-wheel -e .
+    python {toxinidir}/setup.py test


### PR DESCRIPTION
This replaces the used functionality of m2crypto by `asn1crypto` and implements a bunch of python 3 compatibility so that now all tests work on python 2 and 3 and all tests work without m2crypto.

This should be completely backwards compatible.