### PR TITLE
Avoid recursive string decoding/encoding errors on python 2.

### DIFF
--- a/signing_clients/apps.py
+++ b/signing_clients/apps.py
@@ -243,7 +243,6 @@ class Manifest(list):
         ).decode('utf-8')
 
 
-@python_2_unicode_compatible
 class Signature(Manifest):
     omit_individual_sections = True
     digest_manifests = {}


### PR DESCRIPTION
Actually simply fixes the tests.