### PR TITLE
Address make_signed arguments

### DIFF
--- a/signing_clients/apps.py
+++ b/signing_clients/apps.py
@@ -247,7 +247,6 @@ class Manifest(list):
 @python_2_unicode_compatible
 class Signature(Manifest):
     digest_manifests = {}
-    filename = 'zigbert'
 
     @property
     def digest_manifest(self):

--- a/signing_clients/apps.py
+++ b/signing_clients/apps.py
@@ -323,14 +323,13 @@ class JarExtractor(object):
         # section signatures
         return self.signatures.header + b"\n"
 
-    def make_signed(self, signature, outpath, sigpath=None):
+    def make_signed(self, signature, outpath, sigpath):
         if not outpath:
             raise IOError("No output file specified")
 
         if os.path.exists(outpath):
             raise IOError("File already exists: %s" % outpath)
 
-        sigpath = sigpath or self.signatures.filename
         # Normalize to a simple filename with no extension or prefixed
         # directory
         sigpath = os.path.splitext(os.path.basename(sigpath))[0]

--- a/signing_clients/apps.py
+++ b/signing_clients/apps.py
@@ -323,7 +323,7 @@ class JarExtractor(object):
         # section signatures
         return self.signatures.header + b"\n"
 
-    def make_signed(self, signature, outpath, sigpath):
+    def make_signed(self, signed_manifest, signature, outpath, sigpath):
         if not outpath:
             raise IOError("No output file specified")
 
@@ -348,7 +348,7 @@ class JarExtractor(object):
                         continue
                     zout.writestr(f, zin.read(f.filename))
                 zout.writestr("META-INF/manifest.mf", str(self.manifest))
-                zout.writestr("%s.sf" % sigpath, str(self.signatures))
+                zout.writestr("%s.sf" % sigpath, signed_manifest)
                 if self.ids is not None:
                     zout.writestr('META-INF/ids.json', self.ids)
 

--- a/signing_clients/apps.py
+++ b/signing_clients/apps.py
@@ -330,9 +330,13 @@ class JarExtractor(object):
         if os.path.exists(outpath):
             raise IOError("File already exists: %s" % outpath)
 
-        # Normalize to a simple filename with no extension or prefixed
-        # directory
-        sigpath = os.path.splitext(os.path.basename(sigpath))[0]
+        # Enforce a simple filename with no extension (because we use
+        # the sigpath for both signed contents and signature) or prefixed
+        # directory (because we don't handle it and want it to be just
+        # in META-INF)
+        if os.path.basename(sigpath) != sigpath or '.' in sigpath:
+            raise ValueError("sigpath should be a basename with no extension")
+
         sigpath = os.path.join('META-INF', sigpath)
 
         with ZipFile(self.inpath, 'r') as zin:

--- a/signing_clients/apps.py
+++ b/signing_clients/apps.py
@@ -273,9 +273,8 @@ class JarExtractor(object):
     Can also generate a new signed archive, if given a PKCS#7 signature
     """
 
-    def __init__(self, path, outpath=None, ids=None):
+    def __init__(self, path, ids=None):
         self.inpath = path
-        self.outpath = outpath
         self._digests = []
         self._manifest = None
         self._sig = None
@@ -324,8 +323,7 @@ class JarExtractor(object):
         # section signatures
         return self.signatures.header + b"\n"
 
-    def make_signed(self, signature, outpath=None, sigpath=None):
-        outpath = outpath or self.outpath
+    def make_signed(self, signature, outpath, sigpath=None):
         if not outpath:
             raise IOError("No output file specified")
 

--- a/signing_clients/apps.py
+++ b/signing_clients/apps.py
@@ -323,9 +323,6 @@ class JarExtractor(object):
         return self.signatures.header + b"\n"
 
     def make_signed(self, signed_manifest, signature, outpath, sigpath):
-        if not outpath:
-            raise IOError("No output file specified")
-
         if os.path.exists(outpath):
             raise IOError("File already exists: %s" % outpath)
 

--- a/signing_clients/tests/__init__.py
+++ b/signing_clients/tests/__init__.py
@@ -174,7 +174,8 @@ class SigningTest(unittest.TestCase):
 
         signed_file = self.tmp_file('test-jar-signed.zip')
         sigpath = 'zoidberg'
-        extracted.make_signed(signature, signed_file, sigpath=sigpath)
+        extracted.make_signed(str(extracted.signatures), signature,
+                              signed_file, sigpath)
         # Now verify the signed zipfile's contents
         with ZipFile(signed_file, 'r') as zin:
             # sorted(...) should result in the following order:
@@ -202,7 +203,8 @@ class SigningTest(unittest.TestCase):
             signature_digest.update(signature)
 
         signed_file = self.tmp_file('test-jar-signed.zip')
-        extracted.make_signed(signature, signed_file)
+        extracted.make_signed(str(extracted.signatures), signature,
+                              signed_file, 'zigbert')
 
         with ZipFile(signed_file, 'r') as zin:
             files = ['test-file', 'META-INF/manifest.mf',

--- a/signing_clients/tests/__init__.py
+++ b/signing_clients/tests/__init__.py
@@ -222,6 +222,22 @@ class SigningTest(unittest.TestCase):
         signed = JarExtractor(signed_file)
         self.assertEqual(force_bytes(extracted.manifest), force_bytes(signed.manifest))
 
+    def test_make_signed_refuses_weird_sigpath(self):
+        extracted = JarExtractor(get_file('test-jar.zip'))
+
+        # Hardcode the parameters we don't care about in this test
+        signed_manifest = 'abc'
+        signature = 'signed: abc'
+        outpath = 'signed-jar.zip'
+
+        def make_signed(sigpath):
+            return extracted.make_signed(signed_manifest, signature,
+                                         outpath, sigpath)
+
+        self.assertRaises(ValueError, make_signed, 'subdirectory/filename')
+        self.assertRaises(ValueError, make_signed, 'filename.abc')
+
+
     # See https://bugzil.la/1169574
     def test_metainf_case_sensitivity(self):
         self.assertTrue(ignore_certain_metainf_files('meta-inf/manifest.mf'))

--- a/signing_clients/tests/__init__.py
+++ b/signing_clients/tests/__init__.py
@@ -142,7 +142,7 @@ class SigningTest(unittest.TestCase):
     def test_unicode(self):
         extracted = JarExtractor(get_file('test-jar-unicode.zip'))
         self.assertEqual(
-            force_bytes(extracted.manifest).decode('utf-8'), UNICODE_MANIFEST + b"\n")
+            force_bytes(extracted.manifest).decode('utf-8'), UNICODE_MANIFEST + u"\n")
 
     def test_serial_number_extraction(self):
         with open(get_file('zigbert.test.pkcs7.der'), 'rb') as f:

--- a/signing_clients/tests/__init__.py
+++ b/signing_clients/tests/__init__.py
@@ -174,8 +174,12 @@ class SigningTest(unittest.TestCase):
 
         signed_file = self.tmp_file('test-jar-signed.zip')
         sigpath = 'zoidberg'
-        extracted.make_signed(str(extracted.signatures), signature,
-                              signed_file, sigpath)
+        extracted.make_signed(
+            signed_manifest=str(extracted.signatures),
+            signature=signature,
+            outpath=signed_file,
+            sigpath=sigpath
+        )
         # Now verify the signed zipfile's contents
         with ZipFile(signed_file, 'r') as zin:
             # sorted(...) should result in the following order:
@@ -203,8 +207,12 @@ class SigningTest(unittest.TestCase):
             signature_digest.update(signature)
 
         signed_file = self.tmp_file('test-jar-signed.zip')
-        extracted.make_signed(str(extracted.signatures), signature,
-                              signed_file, 'zigbert')
+        extracted.make_signed(
+            signed_manifest=str(extracted.signatures),
+            signature=signature,
+            outpath=signed_file,
+            sigpath='zigbert'
+        )
 
         with ZipFile(signed_file, 'r') as zin:
             files = ['test-file', 'META-INF/manifest.mf',
@@ -231,8 +239,12 @@ class SigningTest(unittest.TestCase):
         outpath = 'signed-jar.zip'
 
         def make_signed(sigpath):
-            return extracted.make_signed(signed_manifest, signature,
-                                         outpath, sigpath)
+            return extracted.make_signed(
+                signed_manifest=signed_manifest,
+                signature=signature,
+                outpath=outpath,
+                sigpath=sigpath
+            )
 
         self.assertRaises(ValueError, make_signed, 'subdirectory/filename')
         self.assertRaises(ValueError, make_signed, 'filename.abc')


### PR DESCRIPTION
This is an attempt to address #25 by implementing the suggestions in that issue: namely, adding a `signed_manifest` argument to `make_signed`, forcing the user to specify what should be used as the manifest. This is the approach I took in sign_xpi_lib, but now that I've reimplemented it here, I'm wondering if the better approach might be to go the other direction and take away options from the user, enforcing only the Mozilla XPI-signing approach (i.e. not changing `self.signatures`, always using `mozilla.rsa`). What do you think?

While we're here, fix a test failure I somehow completely missed in the last PR, and try to clean up the JarExtractor API by getting rid of the `outpath` member field.