### PR TITLE
Fix dependencies, remove latin1 workaround.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,10 @@ setup(
     author='Ryan Tilder',
     author_email='service-dev@mozilla.com',
     url='http://mozilla.org',
-    install_requires=['asn1crypto', 'six'],
+    install_requires=[
+        'asn1crypto>=0.23',
+        'six>=1.10.0'
+    ],
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,

--- a/signing_clients/apps.py
+++ b/signing_clients/apps.py
@@ -18,11 +18,6 @@ from six.moves import cStringIO as StringIO
 from asn1crypto import cms, core as asn1core
 
 
-# Patch asn1crypto teletex codec to actually be latin 1 (iso-8859-1)
-# See https://github.com/wbond/asn1crypto/issues/60 and
-# https://github.com/mozilla/signing-clients/issues/23 for more details
-asn1core.TeletexString._encoding = 'latin1'
-
 headers_re = re.compile(
     r"""^((?:Manifest|Signature)-Version
           |Name


### PR DESCRIPTION
https://github.com/wbond/asn1crypto/commit/1ba880ef26e37151e71b9968ba1d29b2573cfd43
fixes the teletex -> latin1 conversion issue.