### PR TITLE
Set homepage to github project page in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     keywords='web services',
     author='Ryan Tilder',
     author_email='service-dev@mozilla.com',
-    url='http://mozilla.org',
+    url='https://github.com/mozilla/signing-clients/',
     install_requires=[
         'asn1crypto>=0.23',
         'six>=1.10.0'


### PR DESCRIPTION
Since no changelogs are published let's at least link to the github project in `setup.py` to easily find the recent commits when starting from the PyPI page / pyup pull requests.