### PR TITLE
Get rid of Section.algos

### DIFF
--- a/signing_clients/apps.py
+++ b/signing_clients/apps.py
@@ -121,7 +121,7 @@ def _digest(data):
 
 @python_2_unicode_compatible
 class Section(object):
-    __slots__ = ('name', 'algos', 'digests')
+    __slots__ = ('name', 'digests')
 
     def __init__(self, name, digests=None):
         self.name = name


### PR DESCRIPTION
I guess I missed this earlier.

I think this is my last cleanup until we can get off of Python 2.7, because the only other thing I did was remove those nasty `b''` string literals, and make everything a simple str, but while we have to support both 2 and 3, I don't think can do better than that. Besides, changing properties that previously returned bytes and now return strings would break backwards compatibility. (But I'd still be happy to open a PR if you want.)